### PR TITLE
Avoid creating a Docker layer containing the compressed model file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codait/max-base:v1.1.0
+FROM codait/max-base:v1.1.1
 
 # Fill in these with a link to the bucket containing the model and the model file name
 ARG model_bucket=http://max-assets.s3-api.us-geo.objectstorage.softlayer.net/max-facial-emotion-classifier/1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM codait/max-base:v1.1.1
 ARG model_bucket=http://max-assets.s3-api.us-geo.objectstorage.softlayer.net/max-facial-emotion-classifier/1.0
 ARG model_file=assets.tar.gz
 
-RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file}
 RUN apt-get update && apt-get install libgtk2.0 -y && rm -rf /var/lib/apt/lists/*
-RUN tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
+RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file} && \
+  tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt 


### PR DESCRIPTION
Download and delete the compressed model file in the same layer to avoid an (often oversized) additional Docker layer.